### PR TITLE
add and fix code block language labels to fix #26

### DIFF
--- a/build-setup.md
+++ b/build-setup.md
@@ -108,7 +108,7 @@ The other, less common but still handy usecase for Babel with Svelte is transpil
 Example usage:
 </summary>
 
-```html
+```svelte
 <script>
   let foo = {
     bar: {
@@ -236,7 +236,7 @@ export default {
 
 and then you can write your Svelte components with TypeScript:
 
-```html
+```svelte
 <script lang="typescript">
   // Compatible with Svelte v3...
   export const hello: string = 'world';
@@ -314,7 +314,7 @@ export default {
 
 and you can write SCSS/SASS in your Svelte template:
 
-```html
+```svelte
 <style lang="scss">
   $color: red;
   div {

--- a/components.md
+++ b/components.md
@@ -23,7 +23,7 @@ _Maintainers of this Recipe: [swyx](https://twitter.com/swyx)_
 
 We can declare a `data` variable and use the `onMount` lifecycle to fetch on mount and display data in our component:
 
-```html
+```svelte
 <!-- https://svelte.dev/repl/99c18a89f05d4682baa83cb673135f05?version=3.20.1 -->
 <script>
   import { onMount } from "svelte";
@@ -48,7 +48,7 @@ Since it is very common to update your app based on the status of your data fetc
 
 This example is exactly equal to Method 1 above:
 
-```html
+```svelte
 <!-- https://svelte.dev/repl/977486a651a34eb5bd9167f989ae3e71?version=3.20.1 -->
 <script>
   let promise = fetch(
@@ -86,7 +86,7 @@ One flaw with the above approach is that it does not offer a way for the user to
 
 If we don't want to immediately load data on component mount, we can wait for user interaction instead:
 
-```html
+```svelte
 <!-- https://svelte.dev/repl/2a8db7627c4744008203ecf12806eb1f?version=3.20.1 -->
 <script>
   let data;
@@ -113,7 +113,7 @@ However, there are some problems with this approach. You may still need to decla
 
 It would be better to make all these commonplace UI idioms declarative. Await blocks to the rescue again:
 
-```html
+```svelte
 <!-- https://svelte.dev/repl/98ec1a9a45af4d75ac5bbcb1b5bcb160?version=3.20.1 -->
 <script>
   let promise;
@@ -147,7 +147,7 @@ The trick here is we can simply reassign the `promise` to trigger a refetch, whi
 
 Of course, it is up to you what UX you want - you may wish to keep displaying stale data and merely display a loading indicator instead while fetching the new data. Here's a possible solution using a second promise to execute the data fetching while the main promise stays onscreen:
 
-```html
+```svelte
 <!-- https://svelte.dev/repl/21e932515ab24a6fb7ab6d411cce2799?version=3.20.1 -->
 <script>
   let promise1, promise2;
@@ -207,7 +207,7 @@ export function getNewCount() {
 }
 ```
 
-```html
+```svelte
 <script>
   import { getNewCount, count, isFetching } from "./store";
 </script>
@@ -252,7 +252,7 @@ Using `bind:this` allows a component to store a reference to it's children, this
 
 This method simply binds the generated component to an array element based on it's index within the loop.
 
-```html
+```svelte
 <script>
   import Child from "./Child.svelte";
   const array = [
@@ -271,7 +271,7 @@ This method simply binds the generated component to an array element based on it
 
 An alternative is to use an _unique_ key and bind the component to an object, effectively making a hashtable of components.
 
-```html
+```svelte
 <script>
   import Child from "./Child.svelte";
   const array = [

--- a/design-patterns.md
+++ b/design-patterns.md
@@ -37,7 +37,7 @@ While Svelte may not necessary require an asynchronous authentication method, yo
 
 It is important to note that this example includes `preventDefault` to prevent the runtime from making an HTTP request at the instant when the form element gets created: `<form on:submit|preventDefault={submitHandler}>`.
 
-```js
+```svelte
 <script>
   import { session } from './session.js';
   /* session.js:

--- a/language.md
+++ b/language.md
@@ -20,7 +20,7 @@ The simplest way to make your Svelte components reactive is by using an assignme
 
 The following works as expected and update the dom:
 
-```sv
+```svelte
 <script>
   let num = 0;
 
@@ -41,7 +41,7 @@ The only exception to the top-level variable rule is when you are inside an `eac
 
 The following example causes the array and, subsequently, the DOM to be updated:
 
-```sv
+```svelte
 <script>
   let list = [{ n: 1 }, { n: 2 }, { n: 3 }];
 </script>
@@ -53,7 +53,7 @@ The following example causes the array and, subsequently, the DOM to be updated:
 
 This, however, will not:
 
-```sv
+```svelte
 <script>
   let list = [1, 2, 3];
 </script>
@@ -65,7 +65,7 @@ This, however, will not:
 
 The easiest workaround is to just reference the array item by index from inside the each block:
 
-```sv
+```svelte
 <script>
   let list = [1, 2, 3];
 </script>
@@ -81,7 +81,7 @@ Svelte only cares about which _variables_ are being reassigned, not the values t
 
 This is the sort of problem you may run into when dealing with objects. Since objects are passed by reference and not value, you can refer to the same value in many different variables. Let's look at an example:
 
-```sv
+```svelte
 <script>
   let obj = {
     num: 0
@@ -103,7 +103,7 @@ In this example, when we reassign `o.num` we are updating the value assigned to 
 
 Another situation that can sometimes cause unexpected results is when you reassign a function's parameter (as above), and that parameter has the same _name_ as a top-level variable.
 
-```sv
+```svelte
 <script>
   let obj = {
     num: 0
@@ -126,7 +126,7 @@ Reassigning function parameters in this way is the same as reassigning a variabl
 
 In addition to the assignment-based reactivity system, Svelte also has special syntax to define code that should rerun when its dependencies change using labeled statements - `$:`.
 
-```sv
+```svelte
 <script>
   let n = 0;
 
@@ -138,7 +138,7 @@ In addition to the assignment-based reactivity system, Svelte also has special s
 
 Whenever Svelte sees a reactive declaration, it makes sure to execute any reactive statements that depend on one another in the correct order and only when their direct dependencies have changed. A 'direct dependency' is a variable that is referenced inside the reactive declaration itself. References to variables inside functions that a reactive declaration _calls_ are not considered dependencies.
 
-```sv
+```svelte
 <script>
   let n = 0;
 

--- a/publishing.md
+++ b/publishing.md
@@ -58,7 +58,7 @@ docker inspect <container-id>
 
 In the output, look at the `HostConfig` for the `PortBindings` object.
 
-```
+```json
 "Ports": {
   "5000/tcp": [
     {
@@ -71,7 +71,7 @@ In the output, look at the `HostConfig` for the `PortBindings` object.
 
 Update your `npm start` command to serve your assets on the host IP.
 
-```
+```json
 "scripts": {
   "build": "rollup -c",
   "dev": "rollup -c -w",

--- a/walkthroughs.md
+++ b/walkthroughs.md
@@ -34,7 +34,7 @@ For more a more detailed example of the entire setup, check out the example repo
 
 The next step is to create a base icon component (`Icon.svelte`). Start with the markup which will make use of a `slot`. This will allow the `svg` parent to accept children (which will be the paths of the icon).
 
-```js
+```svelte
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width={width}
@@ -56,7 +56,7 @@ The `width`, `height`, and `color` props will have defaults so that the icon wil
 
 Our script will look like this:
 
-```
+```svelte
 <script>
   export let width = 16
   export let height = 16
@@ -71,7 +71,7 @@ The default `color` prop is set to `currentColor` so the icon will inherit the c
 
 To use it, say we had a Svelte component called `PencilAlt.svelte` that contained only our icon svg paths like so:
 
-```
+```svelte
 <path
   d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z"
 />
@@ -84,13 +84,13 @@ To use it, say we had a Svelte component called `PencilAlt.svelte` that containe
 
 We can use the `Icon` component as follows:
 
-```
+```svelte
 <Icon name="pencil-alt"><PencilAlt /></Icon>
 ```
 
 Now, if we’d like to make many sizes for the icon, we can do so very easily:
 
-```
+```svelte
 <p>
   <!-- you can pass in a smaller width and height -->
   <Icon


### PR DESCRIPTION
This adds or fixes the language labels for all of the code blocks. Turns out GitHub does have Svelte-specific highlighting so I changed the HTML ones to Svelte too.