### PR TITLE
Add a note stating that modification on array primitives is supported…

### DIFF
--- a/language.md
+++ b/language.md
@@ -39,6 +39,8 @@ Svelte can see that there is an assignment to a top-level variable and knows to 
 
 The only exception to the top-level variable rule is when you are inside an `each` block. Any assignments to variables inside an `each` block trigger an update. Only assignments to array items that are objects or arrays result in the array itself updating. If the array items are primitives, the change is not traced back to the original array. This is because Svelte only reassigns the actual array items and primitives are passed by value in javascript, not by reference.
 
+> From Svelte version 3.23.1 onwards this issue no longer applies. That means that you can assign to array items primitives and the changes will be relfected in the original array.
+
 The following example causes the array and, subsequently, the DOM to be updated:
 
 ```svelte

--- a/language.md
+++ b/language.md
@@ -2,6 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Reactivity](#reactivity)
@@ -37,9 +38,9 @@ Svelte can see that there is an assignment to a top-level variable and knows to 
 
 #### `each` blocks
 
-The only exception to the top-level variable rule is when you are inside an `each` block. Any assignments to variables inside an `each` block trigger an update. Only assignments to array items that are objects or arrays result in the array itself updating. If the array items are primitives, the change is not traced back to the original array. This is because Svelte only reassigns the actual array items and primitives are passed by value in javascript, not by reference.
+> From **Svelte 3.23.1** onwards the following issue no longer applies. You can now assign to array item primitives and the changes will be reflected in the original array. See this [REPL](https://svelte.dev/repl/bc170b644f554eb29374138167dea4f0?version=3.23.1) running on **Svelte 3.23.1**, where the issue has been fixed. And this [REPL](https://svelte.dev/repl/bc170b644f554eb29374138167dea4f0?version=3.23.0) running on **Svelte 3.23.0** where the issue still applies. What follows is for archival purposes for anyone on **Svelte 3.23.0** and below. For further context see Svelte issue [4744](https://github.com/sveltejs/svelte/issues/4744).
 
-> From Svelte version 3.23.1 onwards this issue no longer applies. That means that you can assign to array items primitives and the changes will be relfected in the original array.
+The only exception to the top-level variable rule is when you are inside an `each` block. Any assignments to variables inside an `each` block trigger an update. Only assignments to array items that are objects or arrays result in the array itself updating. If the array items are primitives, the change is not traced back to the original array. This is because Svelte only reassigns the actual array items and primitives are passed by value in javascript, not by reference.
 
 The following example causes the array and, subsequently, the DOM to be updated:
 


### PR DESCRIPTION
… in svelte 3.23.1 onwards

Check #36 for context

https://github.com/svelte-society/recipes-mvp/issues/36