### PR TITLE
feat: add guide for looping non-array

### DIFF
--- a/language.md
+++ b/language.md
@@ -2,6 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Reactivity](#reactivity)
@@ -245,6 +246,133 @@ The reactive declaration in this example reruns _only_ when `one` changes, we ha
 
 [Back to Table of Contents](https://github.com/svelte-society/recipes-mvp#table-of-contents)
 
+## Looping
+
+`{#each}` block allows you to loop only **array** or **array-like object** (i.e. it has a `.length` property).
+
+Here are some examples if you want to loop through data structures besides array.
+
+### Looping a map
+
+You can use spread operator `[...value]` for [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) to get an array of key value pairs.
+
+```svelte
+<script>
+  const map = new Map([['.svelte', 'Svelte'], ['.js', 'JavaScript']]);
+</script>
+
+{#each [...map] as [key, value]}
+	<div>
+		{key}: {value}
+  </div>
+{/each}
+```
+
+Both [`Map.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys) and [`Map.values()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values) method return an iterable. To use `{#each}` with iterable, you can use spread operator `[...value]` on the iterable.
+
+```svelte
+<script>
+  const map = new Map([['.svelte', 'Svelte'], ['.js', 'JavaScript']]);
+</script>
+
+{#each [...map.keys()] as key}
+	<div>
+		{key}
+  </div>
+{/each}
+
+{#each [...map.values()] as value}
+	<div>
+		{value}
+  </div>
+{/each}
+```
+
+### Looping a set
+
+You can use spread operator `[...value]` for [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) to get an array of items.
+
+```svelte
+<script>
+  const set = new Set(['.svelte', '.js']);
+</script>
+
+{#each [...set] as item}
+	<div>
+		{item}
+	</div>
+{/each}
+```
+
+### Looping a string
+
+[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) is considered an **array-like object** as it has `.length` property.
+
+```svelte
+<script>
+  const string = 'Svelte';
+</script>
+
+{#each string as character}
+	<div>
+		{character}
+	</div>
+{/each}
+```
+
+### Looping a generator function
+
+[Generator function `function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) returns a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) object, which conforms to both the [iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterable_protocol) and the [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterator_protocol).
+
+To use `{#each}` with generator function, you can use spread operator `[...value]` on the generator.
+
+```svelte
+<script>
+	function* generator() {
+		yield '.svelte';
+		yield '.js';
+	}
+</script>
+
+{#each [...generator()] as item}
+	<div>
+		{item}
+	</div>
+{/each}
+```
+
+#### Binding to spreaded item
+
+Once you spread a Map, Set, Generator, or any Iterable, you are creating a new array, and therefore binding (`bind:`) with the item may not work anymore.
+
+```svelte
+<script>
+  const map = new Map([['.svelte', 'Svelte'], ['.js', 'JavaScript']]);
+</script>
+
+{#each [...map] as [key, value]}
+  <!-- You can't change the value of the input, nor the value in the map -->
+  <input bind:value={value} />
+{/each}
+```
+
+To workaround this, you can use `on:input` listener
+
+```svelte
+<script>
+  const map = new Map([['.svelte', 'Svelte'], ['.js', 'JavaScript']]);
+</script>
+
+{#each [...map] as [key, value]}
+  <input
+    {value}
+    on:input={(event) => {
+      map.set(key, event.currentTarget.value);
+      map = map;
+    }}
+  />
+{/each}
+```
 
 ## "Scoped Global" CSS
 
@@ -265,10 +393,7 @@ Sometimes your template code doesn't match your CSS. If you generate html via `{
 
 Now that `p` styling will be output by Svelte, AND it won't leak out to the rest of your app.
 
-
-
 [Back to Table of Contents](https://github.com/svelte-society/recipes-mvp#table-of-contents)
-
 
 ## Passing Values from JS to CSS Variables
 

--- a/language.md
+++ b/language.md
@@ -341,7 +341,7 @@ To use `{#each}` with generator function, you can use spread operator `[...value
 {/each}
 ```
 
-#### Binding to spreaded item
+### Binding to spreaded item
 
 Once you spread a Map, Set, Generator, or any Iterable, you are creating a new array, and therefore binding (`bind:`) with the item may not work anymore.
 


### PR DESCRIPTION
Recipes for `{#each}` with non array or array-like object

Related issue in svelte
- https://github.com/sveltejs/svelte/issues/4289
- https://github.com/sveltejs/svelte/issues/5021