### PR TITLE
add recipe - dirty input checking before window close

### DIFF
--- a/components.md
+++ b/components.md
@@ -313,18 +313,21 @@ Note that when passing a class to component, you may need to set it to global `:
 <script>
 	let value = ''
 	let savedValue = ''
-	import {onMount} from 'svelte'
-	onMount(() => {
-		window.onbeforeunload = e => value === savedValue && undefined
-		return () => window.onbeforeunload = undefined
-	})
+
+	function unload(event) {
+		if (savedValue === value) return;
+		event.preventDefault();
+		event.returnValue = 'dirty value';
+		return 'dirty value';
+	}
 </script>
 <input bind:value />
-<button on:click={() => savedValue = value}
-	disabled={savedValue === value}>Save</button>
+
+<button on:click={() => savedValue = value}>Save</button>
+<svelte:window on:beforeunload={unload} />
 ```
 
-For some reason, using `<svelte:window>` binding doesn't work for this event.
+REPL: https://svelte.dev/repl/00fd6d0df4bb4c6596d6f7ddb6d4b96a?version=3.23.2
 
 ### Form Validation with Yup
 

--- a/components.md
+++ b/components.md
@@ -307,6 +307,25 @@ Note that when passing a class to component, you may need to set it to global `:
 
 ## Form Validation with Svelte
 
+### Prevent Window Close if Input not saved
+
+```svelte
+<script>
+	let value = ''
+	let savedValue = ''
+	import {onMount} from 'svelte'
+	onMount(() => {
+		window.onbeforeunload = e => value === savedValue && undefined
+		return () => window.onbeforeunload = undefined
+	})
+</script>
+<input bind:value />
+<button on:click={() => savedValue = value}
+	disabled={savedValue === value}>Save</button>
+```
+
+For some reason, using `<svelte:window>` binding doesn't work for this event.
+
 ### Form Validation with Yup
 
 [Yup](https://github.com/jquense/yup) is a JavaScript schema builder for value passing and validation. We can use Yup to help us validate forms in Svelte.


### PR DESCRIPTION
add recipe - dirty input checking before window close
![image](https://user-images.githubusercontent.com/6764957/85953082-8d045a00-b9a0-11ea-8e1c-a05284dedbb1.png)


https://svelte.dev/repl/952f51edbb3b4483b0b721e2a015cb17?version=3.23.2

honestly not sure why the `<svelte:window on:beforeunload>` version doesnt work for me.