### PR TITLE
update docs for docker

### DIFF
--- a/publishing.md
+++ b/publishing.md
@@ -2,6 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Packaging Svelte Components for npm](#packaging-svelte-components-for-npm)
@@ -15,6 +16,8 @@ _to be written_
 
 ## Dockerize a Svelte App
 
+To serve a client-side Svelte app from a Docker container, you can put all the build assets into a Docker container and serve them.
+
 Let's pull down the [basic svelte template](https://github.com/sveltejs/template) using [degit](https://github.com/Rich-Harris/degit).
 
 ```
@@ -24,61 +27,79 @@ cd svelte-docker
 
 Next, we need to create a `Dockerfile` in the root of our project.
 
-```
-FROM node:12-alpine
+```dockerfile
+FROM nginx:stable
 
-WORKDIR /app
-
-# copy files and install dependencies
-COPY . ./
-RUN npm install
-RUN npm run build
-
-EXPOSE 5000
-
-CMD ["npm", "start"]
+# upload everything in `public` folder into `/var/www`
+COPY ./public/ /var/www
+# copy nginx config
+COPY ./nginx.conf /etc/nginx/nginx.conf
 ```
 
-You can now build and run your docker image.
+We are using [NGINX](https://www.nginx.com/) to serve the static files from the `/var/www` folder.
+
+Create the `/etc/nginx/nginx.conf`
+
+```nginx
+events {
+}
+http {
+  server {
+    listen 80;
+    server_name _;
+
+    root /var/www/;
+    index index.html;
+
+    # Force all paths to load either itself (js files) or go through index.html.
+    location / {
+        try_files $uri /index.html;
+    }
+  }
+}
+```
+
+You can now build the docker image.
 
 ```
+npm install
+npm run build
 docker build . -t svelte-docker
-docker run -p 5000:5000 svelte-docker
+```
+
+To speed up the build, you can add a `.dockerignore` file in the root of `svelte-docker` folder:
+
+```
+node_modules/
+```
+
+This is to tell Docker to ignore files / folder in the Docker build context.
+
+Now, you can run your docker image.
+
+```
+docker run -p 5000:80 svelte-docker
 ```
 
 Open up your browser at localhost:5000 and you should see your svelte app running!
 
-#### Troubleshooting
+### Building Svelte App in a Docker image
 
-On certain operating systems your docker containers IP may not be mapped to `localhost` on your host machine. This means your app won't be served at `localhost`. To see which IP your container is mapped to on your host machine, run your container then execute the following command:
+If you want to build your Svelte App in a Docker image instead in your machine, you can do it in an intermediate Docker image, that way, it would not contribute to the final Docker image size.
 
+```dockerfile
+FROM node AS build
+
+WORKDIR /app
+COPY . .
+
+RUN npm install
+RUN npm run build
+
+FROM nginx:stable
+
+COPY ./public/ /var/www
+COPY ./nginx.conf /etc/nginx/nginx.conf
 ```
-docker inspect <container-id>
-```
-
-In the output, look at the `HostConfig` for the `PortBindings` object.
-
-```json
-"Ports": {
-  "5000/tcp": [
-    {
-      "HostIp": "0.0.0.0",
-      "HostPort": "5000"
-    }
-  ]
-}
-```
-
-Update your `npm start` command to serve your assets on the host IP.
-
-```json
-"scripts": {
-  "build": "rollup -c",
-  "dev": "rollup -c -w",
-  "start": "sirv public --host 0.0.0.0"
-},
-```
-
-Your dockerized svelte app should now be up and running.
 
 [Back to Table of Contents](https://github.com/svelte-society/recipes-mvp#table-of-contents)


### PR DESCRIPTION
current recipe for dockerizing Svelte app is going to create a fat Docker image, considering having all the `node_modules`, source files, and etc within the Docker image.

Proposing a better recipe where 
- build the Svelte app on the host machine and build the Docker image with only the build files
- build the Svelte app on a intermediate Docker image and build the Docker image with only the build files